### PR TITLE
Provide option to assume zero initial state in ansatz generation

### DIFF
--- a/qiskit_addon_aqc_tensor/ansatz_generation.py
+++ b/qiskit_addon_aqc_tensor/ansatz_generation.py
@@ -119,7 +119,10 @@ def _nonidle_qubits(qc: QuantumCircuit, /):
 
 
 def generate_ansatz_from_circuit(
-    qc: QuantumCircuit, /, *, assume_initial_zero_state=False
+    qc: QuantumCircuit,
+    /,
+    *,
+    qubits_initially_zero=False,
 ) -> tuple[QuantumCircuit, list[float]]:
     """Generate an ansatz from the two-qubit connectivity structure of a circuit."""
     # FIXME: handle classical bits, measurements, resets, and barriers.  maybe
@@ -173,11 +176,9 @@ def generate_ansatz_from_circuit(
 
     active_qubits = sorted([qc.find_bit(q)[0] for q in _nonidle_qubits(qc)])
     for q in active_qubits:
-        params, free_params[q] = _allocate_parameters(
-            param_vec, 2 if assume_initial_zero_state else 3
-        )
+        params, free_params[q] = _allocate_parameters(param_vec, 2 if qubits_initially_zero else 3)
         initial_params.extend([np.nan] * len(params))
-        if assume_initial_zero_state:
+        if qubits_initially_zero:
             params.insert(0, 0.0)
         ansatz.append(ZXZ(params), (q,))
         singles[q] = []

--- a/qiskit_addon_aqc_tensor/ansatz_generation.py
+++ b/qiskit_addon_aqc_tensor/ansatz_generation.py
@@ -118,7 +118,9 @@ def _nonidle_qubits(qc: QuantumCircuit, /):
     }
 
 
-def generate_ansatz_from_circuit(qc: QuantumCircuit, /) -> tuple[QuantumCircuit, list[float]]:
+def generate_ansatz_from_circuit(
+    qc: QuantumCircuit, /, *, assume_initial_zero_state=False
+) -> tuple[QuantumCircuit, list[float]]:
     """Generate an ansatz from the two-qubit connectivity structure of a circuit."""
     # FIXME: handle classical bits, measurements, resets, and barriers.  maybe
     # conditions too?
@@ -138,7 +140,14 @@ def generate_ansatz_from_circuit(qc: QuantumCircuit, /) -> tuple[QuantumCircuit,
         # Following the variable convention at
         # https://docs.quantum.ibm.com/api/qiskit/qiskit.synthesis.OneQubitEulerDecomposer
         theta, phi, lamb = decomposer.angles(mat)
-        for j, r in zip(free_params[q], (lamb, theta, phi)):
+        fp = free_params[q]
+        values: tuple[float, ...] = lamb, theta, phi
+        if len(fp) == 2:
+            # Must be initial gate, where the Z rotation has been dropped.
+            # This makes sense if we assume the input state to this ZXZ block
+            # is |0>.
+            values = values[1:]
+        for j, r in zip(fp, values):
             initial_params[j] = r
 
     def perform_separation(q0: int, q1: int):
@@ -164,8 +173,12 @@ def generate_ansatz_from_circuit(qc: QuantumCircuit, /) -> tuple[QuantumCircuit,
 
     active_qubits = sorted([qc.find_bit(q)[0] for q in _nonidle_qubits(qc)])
     for q in active_qubits:
-        params, free_params[q] = _allocate_parameters(param_vec, 3)
-        initial_params.extend([np.nan] * 3)
+        params, free_params[q] = _allocate_parameters(
+            param_vec, 2 if assume_initial_zero_state else 3
+        )
+        initial_params.extend([np.nan] * len(params))
+        if assume_initial_zero_state:
+            params.insert(0, 0.0)
         ansatz.append(ZXZ(params), (q,))
         singles[q] = []
 

--- a/test/test_ansatz_generation.py
+++ b/test/test_ansatz_generation.py
@@ -30,7 +30,7 @@ def test_ansatz_from_random_circuit_process_fidelity():
 
 def test_ansatz_from_random_circuit_state_fidelity():
     qc = random_circuit(6, 4, max_operands=2)
-    ansatz, initial_params = generate_ansatz_from_circuit(qc, assume_initial_zero_state=True)
+    ansatz, initial_params = generate_ansatz_from_circuit(qc, qubits_initially_zero=True)
     ansatz.assign_parameters(initial_params, inplace=True)
     fidelity = state_fidelity(Statevector(ansatz), Statevector(qc))
     assert fidelity == pytest.approx(1)

--- a/test/test_ansatz_generation.py
+++ b/test/test_ansatz_generation.py
@@ -20,7 +20,7 @@ from qiskit_addon_aqc_tensor import generate_ansatz_from_circuit
 from qiskit_addon_aqc_tensor.ansatz_generation import KAK
 
 
-def test_ansatz_process_fidelity_from_random_circuit():
+def test_ansatz_from_random_circuit_process_fidelity():
     qc = random_circuit(6, 4, max_operands=2)
     ansatz, initial_params = generate_ansatz_from_circuit(qc)
     ansatz.assign_parameters(initial_params, inplace=True)
@@ -28,7 +28,7 @@ def test_ansatz_process_fidelity_from_random_circuit():
     assert fidelity == pytest.approx(1)
 
 
-def test_ansatz_state_fidelity_from_random_circuit():
+def test_ansatz_from_random_circuit_state_fidelity():
     qc = random_circuit(6, 4, max_operands=2)
     ansatz, initial_params = generate_ansatz_from_circuit(qc, assume_initial_zero_state=True)
     ansatz.assign_parameters(initial_params, inplace=True)

--- a/test/test_ansatz_generation.py
+++ b/test/test_ansatz_generation.py
@@ -14,17 +14,25 @@ import numpy as np
 import pytest
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.random import random_circuit
-from qiskit.quantum_info import Operator, process_fidelity
+from qiskit.quantum_info import Operator, Statevector, process_fidelity, state_fidelity
 
 from qiskit_addon_aqc_tensor import generate_ansatz_from_circuit
 from qiskit_addon_aqc_tensor.ansatz_generation import KAK
 
 
-def test_ansatz_from_random_circuit():
+def test_ansatz_process_fidelity_from_random_circuit():
     qc = random_circuit(6, 4, max_operands=2)
     ansatz, initial_params = generate_ansatz_from_circuit(qc)
     ansatz.assign_parameters(initial_params, inplace=True)
     fidelity = process_fidelity(Operator(ansatz), Operator(qc))
+    assert fidelity == pytest.approx(1)
+
+
+def test_ansatz_state_fidelity_from_random_circuit():
+    qc = random_circuit(6, 4, max_operands=2)
+    ansatz, initial_params = generate_ansatz_from_circuit(qc, assume_initial_zero_state=True)
+    ansatz.assign_parameters(initial_params, inplace=True)
+    fidelity = state_fidelity(Statevector(ansatz), Statevector(qc))
     assert fidelity == pytest.approx(1)
 
 

--- a/test/test_aqc_workflows.py
+++ b/test/test_aqc_workflows.py
@@ -52,7 +52,9 @@ def test_basic_workflow(available_backend_fixture, circuit_pair):
     target_mps = tensornetwork_from_circuit(target_circuit, simulator_settings)
     good_mps = tensornetwork_from_circuit(good_circuit, simulator_settings)
     initial_fidelity = abs(compute_overlap(good_mps, target_mps)) ** 2
-    ansatz, initial_parameters = generate_ansatz_from_circuit(good_circuit)
+    ansatz, initial_parameters = generate_ansatz_from_circuit(
+        good_circuit, qubits_initially_zero=True
+    )
     objective = OneMinusFidelity(target_mps, ansatz, simulator_settings)
     result = minimize(
         objective,


### PR DESCRIPTION
The ansatz begins with ZXZ decompositions, but the first RZGate on each qubit has no effect if acting on the initial state.  So, this adds an option to remove that parameter on each qubit.

It's left as an option since it does not make sure to do in the case of unitary AQC.

Right now the option is called `assume_initial_zero_state`.  I'm definitely open to discussing the name of the option.

#### TODO

- [ ] add new argument to docstring - will do this in follow-up PR
- [x] use this flag in the tutorial and tests