### PR TITLE
Add `ansatz` parameter to the objective function

### DIFF
--- a/qiskit_addon_aqc_tensor/objective.py
+++ b/qiskit_addon_aqc_tensor/objective.py
@@ -93,6 +93,11 @@ class OneMinusFidelity:
         """Target tensor network."""
         return self._target_tensornetwork
 
+    @property
+    def ansatz(self) -> QuantumCircuit | None:
+        """Parametrized ansatz circuit."""
+        return self._ansatz
+
 
 __all__ = [
     "OneMinusFidelity",


### PR DESCRIPTION
This seems reasonable, but I haven't developed a strong rationale for it yet.  Another candidate to add is `simulation_settings`, but in some places that is called `settings`.