### PR TITLE
Add `CITATION.bib`

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,12 @@
+@ARTICLE{aqc-tensor-research,
+       author = {{Robertson}, Niall F. and {Akhriev}, Albert and {Vala}, Jiri and {Zhuk}, Sergiy},
+        title = "{Approximate Quantum Compiling for Quantum Simulation: A Tensor Network based approach}",
+      journal = {arXiv e-prints},
+     keywords = {Quantum Physics},
+         year = 2023,
+        month = jan,
+          doi = {10.48550/arXiv.2301.08609},
+archivePrefix = {arXiv},
+       eprint = {2301.08609},
+ primaryClass = {quant-ph}
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,4 @@
+/* Disable backgrounds in code highlighting, which look especially bad in dark mode. */
+.highlight * {
+    background-color: transparent !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ html_theme_options = {
     "sidebar_qiskit_ecosystem_member": False,
 }
 html_static_path = ["_static"]
+html_css_files = ["css/custom.css"]
 templates_path = ["_templates"]
 
 # autodoc/autosummary options

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,21 @@ It has been tested primarily on Trotter circuits to date.  It may, however, be a
 
 (Figure is taken from `arXiv:2301.08609 <https://arxiv.org/abs/2301.08609>`__.)
 
+Developer guide
+---------------
+
+The source code to this package is available `on GitHub <https://github.com/Qiskit/qiskit-addon-aqc-tensor>`__.
+
+The developer guide is located at `CONTRIBUTING.md <https://github.com/Qiskit/qiskit-addon-aqc-tensor/blob/main/CONTRIBUTING.md>`__ in the root of this project's repository.
+
+Citing this project
+-------------------
+
+If you use this package in your research, please cite the reference(s) provided in the ``CITATON.bib`` file in this project's repository:
+
+.. literalinclude:: ../CITATION.bib
+   :language: bibtex
+
 Contents
 --------
 .. toctree::


### PR DESCRIPTION
I got the bibtex snippet for https://arxiv.org/abs/2301.08609 from NASA ADS.

Soon, I'd like to add a second citation, for the addon itself.  First this will likely be a Zenodo link, but I'd also like to submit it to a journal.