### PR TITLE
Pass `GITHUB_BASE_REF` and `GITHUB_REF_NAME` in docs tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,3 +77,5 @@ commands =
   sphinx-build -j auto -W -T --keep-going {posargs} docs/ docs/_build/html
 passenv =
   CI
+  GITHUB_BASE_REF
+  GITHUB_REF_NAME


### PR DESCRIPTION
Update according to https://github.com/Qiskit/qiskit-addon-utils/pull/56

Eric, please feel free to merge if you agree.