### PR TITLE
Rephrase tutorial as step 1 of a Qiskit pattern

### DIFF
--- a/docs/tutorials/01_initial_state_aqc.ipynb
+++ b/docs/tutorials/01_initial_state_aqc.ipynb
@@ -13,12 +13,12 @@
     "\n",
     "- **Step 1: Map to quantum problem**\n",
     "    - Initialize our problem's Hamiltonian and observable(s)\n",
-    "    - <font color='#0F62FE'>Determine the longest evolution time feasible using tensor networks</font>\n",
-    "    - <font color='#0F62FE'>Generate Trotterized time-evolution circuits</font>\n",
-    "- **Step 2: Optimize the problem**\n",
+    "    - <font color='#0F62FE'>Generate a target tensor-network state for the initial portion of the circuit</font>\n",
     "    - <font color='#0F62FE'>Generate a low-depth circuit which approximates the portion being compressed</font>\n",
     "    - <font color='#0F62FE'>Generate a general ansatz from that circuit</font>\n",
     "    - <font color='#0F62FE'>Optimize the parameters to bring the ansatz as close as possible to the target</font>\n",
+    "    - <font color='#0F62FE'>Add subsequent Trotter steps to the optimized ansatz</font>\n",
+    "- **Step 2: Optimize for target hardware**\n",
     "    - Transpile the circuit for hardware\n",
     "- **Step 3: Execute experiments**\n",
     "    - Use a fake backend for simplicity\n",
@@ -31,7 +31,7 @@
    "id": "79042f19-241d-48fb-aa87-134a93082c94",
    "metadata": {},
    "source": [
-    "## Step 1: Map to quantum problem\n",
+    "## Step 1: Map to quantum circuit and operator\n",
     "\n",
     "### Set up a model Hamiltonian and observable\n",
     "\n",
@@ -92,7 +92,7 @@
    "id": "70aa63a7-7560-4b29-9391-e1f42abdf1fd",
    "metadata": {},
    "source": [
-    "## Determine how much of the time evolution to simulate classically\n",
+    "### Determine how much of the time evolution to simulate classically\n",
     "\n",
     "Our overall goal is to simulate time evolution of the above model Hamiltonian.  We do so by Trotter evolution, which we split into two portions:\n",
     "\n",
@@ -209,16 +209,6 @@
     "    synthesis=SuzukiTrotter(reps=aqc_comparison_num_trotter_steps),\n",
     "    time=aqc_evolution_time,\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "817839e7-17e7-4dcb-b620-a7711aeb2edf",
-   "metadata": {},
-   "source": [
-    "## Step 2: Optimize for target hardware\n",
-    "\n",
-    "Step 2 of a [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns) is to optimize for target hardware.  In an AQC-Tensor workflow, the first sub-step is to use the AQC method to optimize the initial portion of the circuit.  Then, one combines it with the subsequent time evolution circuit and transpiles the resulting circuit to the instruction set of the target hardware."
    ]
   },
   {
@@ -496,12 +486,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29b4caeb-0e28-43a7-b7ee-da4513a4f0a3",
+   "id": "817839e7-17e7-4dcb-b620-a7711aeb2edf",
    "metadata": {},
    "source": [
-    "### Transpile for execution on target hardware\n",
+    "## Step 2: Transpile for execution on target hardware\n",
     "\n",
-    "Finally, one can transpile this circuit and any desired observable(s) for execution on a target device.  Here we are using a fake backend provided by `qiskit-ibm-runtime`."
+    "In Step 2 of a [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns), we  transpile this circuit and any desired observable(s) for execution on a target device.  Here we are using a fake backend provided by `qiskit-ibm-runtime`."
    ]
   },
   {


### PR DESCRIPTION
After thinking about AQC a while longer, I've concluded that it actually should in many ways be thought of a step 1 of a qiskit pattern.  It's not so much about compressing an existing circuit as it is about making the best possible circuit to simulate a physical system.  (And maybe it will have other applications outside of Trotter circuits.)  After all, the target tensor network might be generated by a physics simulation (e.g., TEBD) rather than a circuit simulation.  This also aligns with the concept of unitary AQC, where we optimize a unitary and then repeat it some number of times in order to generate our circuit.

Related to https://github.com/Qiskit/documentation/pull/2243