### PR TITLE
Fix development version tests

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -38,26 +38,33 @@ jobs:
         run: |
           git clone https://github.com/Qiskit/qiskit
           cd qiskit
+          git rev-parse HEAD
           python -m build --wheel
       - name: Build qiskit-ibm-runtime development wheel
         run: |
           git clone https://github.com/Qiskit/qiskit-ibm-runtime
           cd qiskit-ibm-runtime
+          git rev-parse HEAD
           python -m build --wheel
       - name: Build qiskit-addon-utils development wheel
         run: |
           git clone https://github.com/Qiskit/qiskit-addon-utils
           cd qiskit-addon-utils
+          git rev-parse HEAD
+          # Unpin qiskit<2
+          extremal-python-dependencies pin-dependencies --inplace qiskit
           python -m build --wheel
       - name: Build qiskit-quimb development wheel
         run: |
           git clone https://github.com/qiskit-community/qiskit-quimb
           cd qiskit-quimb
+          git rev-parse HEAD
           python -m build --wheel
       - name: Build quimb development wheel
         run: |
           git clone https://github.com/jcmgray/quimb
           cd quimb
+          git rev-parse HEAD
           python -m build --wheel
       - name: Pin development versions
         shell: bash


### PR DESCRIPTION
https://github.com/Qiskit/qiskit/pull/13408 bumped the qiskit SDK version to 2.0 on the development branch.  However, qiskit-addon-utils is (rightly, until qiskit 2.0 is released) pinned to qiskit<2.  Thus, we must unpin this in the development version tests to be able to test against it.