### PR TITLE
Move kahypar from notebook-dependencies to quimb deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ quimb = [
     "quimb>=1.8.4, <2; python_version < '3.13'",
     "qiskit-quimb>=0.0.4, <0.1; python_version < '3.13'",
     "networkx>=2.3; python_version < '3.13'",
+    # The following line silences a warning from cotengra, which is
+    # a dependency of quimb.  We install kahypar only on platforms
+    # where we have verified that wheels are available on pypi.
+    "kahypar>=1.3.5; sys_platform == 'linux' or (sys_platform == 'darwin' and python_version < '3.12')",
 ]
 quimb-autograd = [
     "qiskit-addon-aqc-tensor[quimb]",
@@ -98,10 +102,6 @@ notebook-dependencies = [
     "matplotlib>=3.3.4",
     "ipywidgets>=7.5.1",
     "pylatexenc>=2.0",
-    # The following line silences a warning from cotengra, which is
-    # a dependency of quimb.  We install kahypar only on platforms
-    # where we have verified that wheels are available on pypi.
-    "kahypar>=1.3.5; sys_platform == 'linux' or (sys_platform == 'darwin' and python_version < '3.12')",
 ]
 
 [project.urls]


### PR DESCRIPTION
We might as well install it any time we are using quimb, in order to silence a warning and possibly optimize performance.