### PR TITLE
Test all python versions on macOS

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -20,11 +20,9 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
-          - os: macos-latest
-            python-version: "3.12"
           - os: windows-latest
             python-version: "3.12"
     steps:


### PR DESCRIPTION
There are some complicated dependencies, since some of the wheels are only available for certain operating systems and python versions (particularly kahypar).  So, I think to be safe we should test against all python versions on macOS.