### PR TITLE
Update intersphinx mapping URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,14 +126,14 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "qiskit-ibm-runtime": (
-        "https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/",
+        "https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/",
         None,
     ),
     "qiskit-aer": ("https://qiskit.github.io/qiskit-aer/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
-    "qiskit_addon_utils": ("https://docs.quantum.ibm.com/api/qiskit-addon-utils/", None),
+    "qiskit_addon_utils": ("https://quantum.cloud.ibm.com/docs/api/qiskit-addon-utils/", None),
     "quimb": ("https://quimb.readthedocs.io/en/latest/", None),
 }
 


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.