### PR TITLE
Modify `qiskit_ansatz_to_quimb` to use provided circuit factory

### DIFF
--- a/docs/how-tos/01_quimb_tnoptimizer.ipynb
+++ b/docs/how-tos/01_quimb_tnoptimizer.ipynb
@@ -173,7 +173,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circ, conversion_context = qiskit_ansatz_to_quimb(ansatz, initial_parameters)"
+    "circ, conversion_context = qiskit_ansatz_to_quimb(\n",
+    "    ansatz, initial_parameters, simulator.quimb_circuit_factory\n",
+    ")"
    ]
   },
   {

--- a/qiskit_addon_aqc_tensor/simulation/quimb/__init__.py
+++ b/qiskit_addon_aqc_tensor/simulation/quimb/__init__.py
@@ -210,10 +210,12 @@ class QiskitQuimbConversionContext:
 
 
 def qiskit_ansatz_to_quimb(
-    qc: QuantumCircuit, initial_parameters: Sequence[float], /
+    qc: QuantumCircuit,
+    initial_parameters: Sequence[float],
+    quimb_circuit_factory,
+    /,
 ) -> tuple[quimb.tensor.Circuit, QiskitQuimbConversionContext]:
     """Convert a Qiskit ansatz to a Quimb parametrized circuit."""
-    import quimb.tensor as qtn
     from qiskit_quimb import quimb_gate
 
     qc = qc.decompose(AnsatzBlock)
@@ -222,7 +224,7 @@ def qiskit_ansatz_to_quimb(
             f"{len(initial_parameters)} parameter(s) were passed, but "
             f"the circuit has {qc.num_parameters} parameter(s)."
         )
-    circ = qtn.Circuit(qc.num_qubits)
+    circ = quimb_circuit_factory(qc.num_qubits, convert_eager=False)
     mapping: list[tuple[int, int, float, float]] = [(-1, -1, 0.0, 0.0)] * qc.num_parameters
     j = 0
     parameter_lookup: dict[Parameter, int] = {
@@ -380,7 +382,9 @@ class _QuimbGradientContext:
         import quimb.tensor as qtn
 
         self.quimb_ansatz, self.conversion_ctx = qiskit_ansatz_to_quimb(
-            objective._ansatz, [0.0] * objective._ansatz.num_parameters
+            objective._ansatz,
+            [0.0] * objective._ansatz.num_parameters,
+            settings.quimb_circuit_factory,
         )
         self.tnopt = qtn.TNOptimizer(
             self.quimb_ansatz,


### PR DESCRIPTION
Now that quimb provides a ``convert_eager`` boolean, we can set it rather than calling the `qtn.Circuit` constructor. The old way, we would lose any parameters that had been set in the simulator.

- [ ] Get first tutorial notebook to work
- [ ] Release note