### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: windows-latest
             python-version: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = [
 
 [project.optional-dependencies]
 quimb = [
-    "quimb>=1.11.0, <2; python_version < '3.14'",
-    "qiskit-quimb>=0.0.9, <0.1; python_version < '3.14'",
-    "networkx>=2.3; python_version < '3.14'",
+    "quimb>=1.11.0, <2; python_version < '3.15'",
+    "qiskit-quimb>=0.0.9, <0.1; python_version < '3.15'",
+    "networkx>=2.3; python_version < '3.15'",
     # The following line silences a warning from cotengra, which is
     # a dependency of quimb.  We install kahypar only on platforms
     # where we have verified that wheels are available on pypi.

--- a/releasenotes/notes/python-3.14-support-b81d6d9fa4a8e643.yaml
+++ b/releasenotes/notes/python-3.14-support-b81d6d9fa4a8e643.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Support for Python 3.14.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.4.3
-envlist = py{39,310,311,312,313}{,-notebook}, lint, coverage, docs
+envlist = py{39,310,311,312,313,314}{,-notebook}, lint, coverage, docs
 isolated_build = True
 
 [testenv]
@@ -14,12 +14,12 @@ extras =
 commands =
   pytest {posargs}
 
-[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-}aer-only]
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-,py314-}aer-only]
 extras =
   test
   aer
 
-[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-}quimb-only]
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-,py314-}quimb-only]
 extras =
   test
   quimb-all
@@ -50,7 +50,7 @@ commands =
   sphinx-alt-text-validator -f qiskit_addon_aqc_tensor
   nbqa pylint -rn --disable=wrong-import-order,wrong-import-position docs/
 
-[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-}notebook]
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-,py314-}notebook]
 extras =
   nbtest
   notebook-dependencies


### PR DESCRIPTION
- [x] Waiting on https://github.com/Qiskit/qiskit-aer/issues/2378
- [x] The lines for the quimb dependency only install for python < 3.14 because binary distributions of kahypar do not exist for it yet - see https://github.com/kahypar/kahypar/issues/210#issuecomment-2487467147 for when this happened for Python 3.12 and 3.13.
- [x] Add release note - or update note if one already exists.