### PR TITLE
Bump development tests to use Python 3.10 minimum

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', 3.12]
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
In recent days, both quimb and Qiskit have dropped support for Python 3.9 on their development branches, and since then this repository's CI cron job has been failing. This PR fixes CI by bumping to Python 3.10. We may in the future abruptly drop support for Python 3.9, either when we feel the time is right or when there is a reason to bump the required version of either Qiskit or quimb. Until then, people can continue to use Python 3.9, but they are encouraged to upgrade as soon as possible since it is EOL.