### PR TITLE
Bump development tests to use python 3.11 and 3.13

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.13']
+        python-version: ['3.11', '3.13']
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Similar to #135, but necessary already because of #141.