### PR TITLE
INSTALL.rst: Update `pip install` line to be compatible with zsh

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -45,7 +45,7 @@ Upgrade pip and install the AQC-Tensor package.  To meaningfully use the package
 .. code:: sh
 
     pip install --upgrade pip
-    pip install qiskit-addon-aqc-tensor[quimb-jax]
+    pip install 'qiskit-addon-aqc-tensor[quimb-jax]'
 
 
 .. _Option 2:


### PR DESCRIPTION
A user experienced an error when trying to run this line on `zsh`, and the solution is to add single quotes.  We did this on a later line of this file that installs jupyterlab, but we missed this one.