### PR TITLE
Fix qubit ordering of Quimb backend `out_state`

### DIFF
--- a/qiskit_addon_aqc_tensor/simulation/quimb/__init__.py
+++ b/qiskit_addon_aqc_tensor/simulation/quimb/__init__.py
@@ -122,7 +122,13 @@ class QuimbSimulator(TensorNetworkSimulationSettings):
         gates = qiskit_quimb.quimb_gates(qc)
         circ.apply_gates(gates, progbar=self.progbar)
         if out_state is not None:
-            out_state[:] = np.squeeze(circ.psi.to_dense())
+            # Quimb orders the dense statevector with qubit 0 as the most
+            # significant bit, whereas Qiskit treats qubit 0 as the least
+            # significant.  Reverse the qubit axes to convert to Qiskit's
+            # convention before writing into ``out_state``.
+            num_qubits = qc.num_qubits
+            dense = np.asarray(circ.psi.to_dense()).reshape([2] * num_qubits)
+            out_state[:] = dense.transpose(*range(num_qubits - 1, -1, -1)).reshape(-1)
         return circ
 
 

--- a/releasenotes/notes/quimb-out-state-qubit-order-3f9c1a7e8b2d4506.yaml
+++ b/releasenotes/notes/quimb-out-state-qubit-order-3f9c1a7e8b2d4506.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed the qubit ordering of the ``out_state`` array populated by the Quimb
+    backend's :func:`~qiskit_addon_aqc_tensor.simulation.tensornetwork_from_circuit`
+    and :func:`~qiskit_addon_aqc_tensor.simulation.apply_circuit_to_state`.
+    Quimb orders the dense statevector with qubit 0 as the most-significant bit,
+    whereas Qiskit treats qubit 0 as the least-significant bit.  The returned
+    ``out_state`` now follows Qiskit's convention, matching the Aer backend.
+    Previously, the amplitudes were written in reversed-qubit order, which only
+    happened to be correct for states that are symmetric under qubit reversal.

--- a/test/simulation/test_statevector.py
+++ b/test/simulation/test_statevector.py
@@ -34,4 +34,4 @@ class TestExactStatevector:
         qc.rxx(0.7, 0, 2)
         out_state = np.zeros([8], dtype=complex)
         tensornetwork_from_circuit(qc, available_backend_fixture, out_state=out_state)
-        abs(np.vdot(Statevector(qc).data, out_state)) == pytest.approx(1)
+        assert abs(np.vdot(Statevector(qc).data, out_state)) == pytest.approx(1)

--- a/test/simulation/test_statevector.py
+++ b/test/simulation/test_statevector.py
@@ -13,8 +13,8 @@
 import numpy as np
 import pytest
 from qiskit import QuantumCircuit
-
 from qiskit.quantum_info import Statevector
+
 from qiskit_addon_aqc_tensor.simulation import (
     tensornetwork_from_circuit,
 )


### PR DESCRIPTION
## Summary

The Quimb backend was populating the `out_state` array in the wrong qubit order. Quimb orders the dense statevector with qubit 0 as the **most**-significant bit, whereas Qiskit treats qubit 0 as the **least**-significant bit. As a result, `out_state` was effectively bit-reversed — which only happened to be correct for states that are symmetric under qubit reversal (e.g. a Bell state), so the existing tests never caught it.

The fix reshapes the dense vector into per-qubit axes, reverses them, and flattens back, so `out_state` follows Qiskit's little-endian convention — matching the Aer backend.

## How it was found

This surfaced while working on the ruff bump in #152. The test `test_random_circuit_statevector` contained a bare comparison:

```python
abs(np.vdot(Statevector(qc).data, out_state)) == pytest.approx(1)
```

which asserted *nothing* (ruff `B015` flagged it). Adding the missing `assert` revealed that all three Quimb backends produced an overlap of **0.5** instead of **1.0** for a circuit with `ryy`/`rxx` gates — amplitudes at indices `011`↔`110` were swapped. The Aer backends were unaffected.

## Changes

- `quimb/__init__.py`: reverse qubit axes when writing `out_state` in `_construct_circuit`.
- `test/simulation/test_statevector.py`: add the missing `assert` (this is what now exercises the fix).
- Release note.

## Testing

`tox -e py` passes (62 passed); all 3 Quimb backends + 2 Aer backends now give overlap 1.0 for the random circuit, and the Bell-state test is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)