### PR TITLE
Bump Python version in docs workflow to remove stale Python 3.9 deprecation warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The rendered output of `docs/tutorials/01_initial_state_aqc.ipynb` (visible at https://qiskit.github.io/qiskit-addon-aqc-tensor/tutorials/01_initial_state_aqc.html) shows a `DeprecationWarning` about Python 3.9 in the following executed cells:

<img width="1200" height="412" alt="image" src="https://github.com/user-attachments/assets/dcddbb37-d887-4425-b8e3-fa981421c7a8" />

<img width="1196" height="370" alt="image" src="https://github.com/user-attachments/assets/01461086-67a3-47dd-8ca0-16e9d3f95eda" />

This warning is stale and comes from the prior execution environment supporting Python 3.9, which after closing Issue #175 is no longer supported.

## Fix

~~Re-executed `docs/tutorials/01_initial_state_aqc.ipynb` in a clean environment on a currently supported Python version (3.12.3), refreshing only the notebook's output cells so the stale Python 3.9 deprecation warning no longer appears; no markdown or code cell content was changed.~~

Bumped the Python version from 3.9 to 3.12 in `stable/0.3` to match the version used on `main`.
