### PR TITLE
Fix the quimb backend following its CircuitBase refactor

### DIFF
--- a/qiskit_addon_aqc_tensor/simulation/quimb/__init__.py
+++ b/qiskit_addon_aqc_tensor/simulation/quimb/__init__.py
@@ -39,10 +39,14 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
     import quimb.tensor
-    from quimb.tensor import Circuit, CircuitMPS
+    from quimb.tensor import Circuit, CircuitBase, CircuitMPS
 else:
     Circuit = ModuleType("quimb.tensor", "Circuit")
     CircuitMPS = ModuleType("quimb.tensor", "CircuitMPS")
+    # quimb >= 1.14.1.dev76 introduced `CircuitBase`, with `Circuit` and
+    # `CircuitMPS` as siblings deriving from it.  On older quimb the root is
+    # `Circuit` itself, and `CircuitMPS` and others derive from it.
+    CircuitBase = ModuleType("quimb.tensor", "CircuitBase", allow_fail=True) | Circuit
 
 
 def _on_quimb_import(_module) -> None:
@@ -69,7 +73,7 @@ class QuimbCircuitFactory(Protocol):
 
     def __call__(  # noqa: D102
         self, *, N: int, psi0: quimb.tensor.TensorNetworkGenVector | None = None
-    ) -> quimb.tensor.Circuit:  # pragma: no cover
+    ) -> CircuitBase:  # pragma: no cover
         ...
 
 
@@ -128,7 +132,7 @@ class QuimbSimulator(TensorNetworkSimulationSettings):
 
 
 @dispatch
-def compute_overlap(circ1: Circuit, circ2: Circuit, /) -> complex:
+def compute_overlap(circ1: CircuitBase, circ2: CircuitBase, /) -> complex:
     return complex(circ1.psi.H @ circ2.psi)
 
 
@@ -139,7 +143,7 @@ def tensornetwork_from_circuit(
     /,
     *,
     out_state: np.ndarray | None = None,
-) -> quimb.tensor.Circuit:
+) -> CircuitBase:
     return settings._construct_circuit(qc, out_state=out_state)
 
 
@@ -186,12 +190,12 @@ def _apply_two_qubit_gate_inplace(
 @dispatch
 def apply_circuit_to_state(
     qc: QuantumCircuit,
-    circ0: Circuit,
+    circ0: CircuitBase,
     settings: QuimbSimulator,
     /,
     *,
     out_state: np.ndarray | None = None,
-) -> quimb.tensor.Circuit:
+) -> CircuitBase:
     """Apply a quantum circuit to a tensor network state.
 
     The input state (``psi``) is not modified.
@@ -425,7 +429,10 @@ def tnoptimizer_objective_kwargs(objective: MaximizeStateFidelity, /) -> dict[st
     import quimb.tensor as qtn
 
     target = objective.target
-    if isinstance(target, qtn.Circuit):
+    # `CircuitBase` is a new base class introduced in quimb 1.14.1.dev76, at
+    # https://github.com/jcmgray/quimb/pull/399
+    circuit_base = getattr(qtn, "CircuitBase", qtn.Circuit)
+    if isinstance(target, circuit_base):
         target = target.psi
     return {
         "loss_fn": maximize_state_fidelity_loss_function,
@@ -434,7 +441,7 @@ def tnoptimizer_objective_kwargs(objective: MaximizeStateFidelity, /) -> dict[st
 
 
 def maximize_state_fidelity_loss_function(
-    circ: quimb.tensor.Circuit, /, *, target: quimb.tensor.TensorNetworkGenVector
+    circ: CircuitBase, /, *, target: quimb.tensor.TensorNetworkGenVector
 ):
     """Loss function for use with Quimb, compatible with automatic differentiation.
 

--- a/releasenotes/notes/quimb-circuitbase-refactor-0007ab555935ee31.yaml
+++ b/releasenotes/notes/quimb-circuitbase-refactor-0007ab555935ee31.yaml
@@ -3,4 +3,4 @@ fixes:
   - |
     Fixed the quimb backend to be compatible with versions of quimb following
     the `CircuitBase refactor <https://github.com/jcmgray/quimb/pull/399>`__.
-    quimb 1.14.0 is the last released version of quimb before the refactor.
+    quimb 1.14.0 is the last released version before the refactor.

--- a/releasenotes/notes/quimb-circuitbase-refactor-0007ab555935ee31.yaml
+++ b/releasenotes/notes/quimb-circuitbase-refactor-0007ab555935ee31.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed the quimb backend to be compatible with versions of quimb following
+    the `CircuitBase refactor <https://github.com/jcmgray/quimb/pull/399>`__.
+    quimb 1.14.0 is the last released version of quimb before the refactor.


### PR DESCRIPTION
This adds support for recent development versions of quimb while maintaining compatibility with older versions.

- [x] Add a release note

Fixes #199.