### PR TITLE
Prepare 0.3.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qiskit-addon-aqc-tensor"
-version = "0.3.0"
+version = "0.3.1"
 description = "Approximate quantum compilation with tensor networks"
 readme = "README.md"
 license = {file = "LICENSE.txt"}


### PR DESCRIPTION
The motivation for cutting a release is to get #200 to users before the next quimb release.  Otherwise, we will end up in a situation where the latest release of the addon does not work with the latest quimb.