### PR TITLE
Fix doc build with temporary workaround until quimb 1.14.1 is released

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,12 @@ autodoc_default_options = {
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 
+# `CircuitBase` lives in a `TYPE_CHECKING` block but does not yet exist in a
+# the latest quimb release (1.14.0), so sphinx-autodoc-typehints cannot import
+# it at doc-build time.  After quimb 1.14.1 is released, the following line can
+# be removed.
+suppress_warnings = ["sphinx_autodoc_typehints.guarded_import"]
+
 
 # nbsphinx options (for tutorials)
 nbsphinx_timeout = 180


### PR DESCRIPTION
`CircuitBase` is imported inside a `TYPE_CHECKING` block but does not yet exist in a released quimb, so sphinx-autodoc-typehints cannot import it at doc-build time.  Under `sphinx-build -W` this guarded-import warning fails the docs build.

Suppress just that warning subtype until quimb releases a version containing `CircuitBase`, at which point the line can be removed.